### PR TITLE
call notifyEndpoint only at the end of each operation

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -193,15 +193,6 @@ func performBackup(instance, backup string, tagsMap map[string]string, partSize 
 		return err
 	}
 
-	notifyEvent(eventInfo{
-		OpType:    Backup,
-		State:     Started,
-		Name:      backup,
-		Instance:  instance,
-		StartedAt: &startedAt,
-		RawURL:    r.URL.String(),
-	}, notifyEndpoint)
-
 	localPath := path.Join(globalContext.StagingRoot, backup)
 	cmd := exec.Command("lxc", "export", instance, localPath)
 	optimized := r.Form.Get("optimize") == "true"
@@ -267,15 +258,6 @@ func performRestore(instance, backup string, startedAt time.Time, r *http.Reques
 	if err != nil {
 		return err
 	}
-
-	notifyEvent(eventInfo{
-		OpType:    Restore,
-		State:     Started,
-		Name:      backup,
-		Instance:  instance,
-		StartedAt: &startedAt,
-		RawURL:    r.URL.String(),
-	}, notifyEndpoint)
 
 	opts := minio.GetObjectOptions{}
 	obj, err := globalContext.Clnt.GetObject(context.Background(), globalContext.Bucket, path.Join(instance, backup), opts)


### PR DESCRIPTION
Some API clients might send a `state` in the `notifyEndpoint`, to be round tripped when lxmin performs the callback. If this `state` contains a `nonce` and lxmin performs the callback twice, the second callback will fail because the `nonce` was already consumed in the first.

By deleting the first callback and leaving only the last one, API clients can rely on the HTTP response to get feedback on the operation creation, and in the callback at the end to know how it went.