### PR TITLE
Backup and restore profiles along with an instance

### DIFF
--- a/backup.go
+++ b/backup.go
@@ -18,8 +18,10 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"mime"
@@ -37,11 +39,12 @@ import (
 	"github.com/minio/cli"
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/tags"
+	"gopkg.in/yaml.v2"
 )
 
 var backupFlags = []cli.Flag{
 	cli.BoolFlag{
-		Name:  "optimize, O",
+		Name:  "optimized, O",
 		Usage: "use storage driver optimized format",
 	},
 	cli.StringFlag{
@@ -105,11 +108,143 @@ func backupMain(c *cli.Context) error {
 		return fmt.Errorf("no instance found by name: '%s'", instance)
 	}
 
-	backup := "backup_" + time.Now().Format("2006-01-02-15-0405") + ".tar.gz"
-	localPath := path.Join(globalContext.StagingRoot, backup)
+	backupNamePrefix := "backup_" + time.Now().Format("2006-01-02-15-0405")
+
+	// Save profiles to files.
+	profiles, profileInfo, err := backupProfiles(globalContext, instance, backupNamePrefix)
+	if err != nil {
+		return err
+	}
+
+	instanceBackupName, instanceBackupSize, err := backupInstance(globalContext, c.Bool("optimized"), instance, backupNamePrefix)
+	if err != nil {
+		return err
+	}
+
+	// Backup to MinIO
+
+	// Collect total upload size.
+	var totalSize int64
+	backupPath := path.Join(globalContext.StagingRoot, instanceBackupName)
+	if st, err := os.Stat(backupPath); err != nil {
+		return fmt.Errorf("Unable to stat file %s: %v", backupPath, err)
+	} else {
+		totalSize = st.Size()
+	}
+	for _, v := range profileInfo {
+		totalSize += v.Size
+	}
+
+	progress := pb.Start64(totalSize)
+	progress.Set(pb.Bytes, true)
+
+	if err := uploadInstanceBackup(globalContext, c.Bool("optimized"), instance, instanceBackupName, instanceBackupSize, progress, tagsSet, partSize); err != nil {
+		return err
+	}
+	if err := uploadProfilesBackup(globalContext, instance, profiles, profileInfo, progress, tagsSet, partSize); err != nil {
+		return err
+	}
+
+	progress.Finish()
+	return err
+}
+
+func uploadInstanceBackup(ctx *lxminContext, optimized bool, instance, backupName string, size int64, bar *pb.ProgressBar, tagsSet *tags.Tags, partSize int64) error {
+	usermetadata := map[string]string{}
+	// Save additional information if the backup is optimized or not.
+	usermetadata["optimized"] = strconv.FormatBool(optimized)
+	usermetadata["compressed"] = "true" // This is always true.
+
+	fpath := path.Join(ctx.StagingRoot, backupName)
+	barReader, err := newBarUpdateReader(fpath, bar, tmplUp)
+	if err != nil {
+		return err
+	}
+
+	defer barReader.Close()
+	defer os.Remove(fpath)
+	opts := minio.PutObjectOptions{
+		UserTags:     tagsSet.ToMap(),
+		PartSize:     uint64(partSize),
+		UserMetadata: usermetadata,
+		ContentType:  mime.TypeByExtension(".tar.gz"),
+	}
+	_, err = globalContext.Clnt.PutObject(context.Background(), globalContext.Bucket, path.Join(instance, backupName), barReader, size, opts)
+	if err != nil {
+		return fmt.Errorf("Error uploading file %s: %v", fpath, err)
+	}
+	return nil
+}
+
+func uploadProfilesBackup(ctx *lxminContext, instance string, pList []string, prInfo map[string]profileInfo, bar *pb.ProgressBar, tagsSet *tags.Tags, partSize int64) error {
+	for _, profile := range pList {
+		err := func() error {
+			profileFile := prInfo[profile].FileName
+			size := prInfo[profile].Size
+			fpath := path.Join(ctx.StagingRoot, profileFile)
+			barReader, err := newBarUpdateReader(fpath, bar, tmplUp)
+			if err != nil {
+				return err
+			}
+			defer barReader.Close()
+			defer os.Remove(fpath)
+
+			opts := minio.PutObjectOptions{
+				UserTags:    tagsSet.ToMap(),
+				PartSize:    uint64(partSize),
+				ContentType: mime.TypeByExtension(".yaml"),
+			}
+			_, err = ctx.Clnt.PutObject(context.Background(), ctx.Bucket, path.Join(instance, profileFile), barReader, size, opts)
+			if err != nil {
+				return fmt.Errorf("Error uploading file %s: %v", fpath, err)
+			}
+			return nil
+		}()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type barUpdateReader struct {
+	r   io.Reader
+	bar *pb.ProgressBar
+}
+
+func newBarUpdateReader(fpath string, bar *pb.ProgressBar, tmpl string) (*barUpdateReader, error) {
+	r, err := os.Open(fpath)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to open %s: %v", fpath, err)
+	}
+
+	bar.SetTemplateString(fmt.Sprintf(tmpl, path.Base(fpath)))
+
+	return &barUpdateReader{
+		r:   r,
+		bar: bar,
+	}, nil
+}
+
+func (b *barUpdateReader) Read(p []byte) (n int, err error) {
+	n, err = b.r.Read(p)
+	b.bar.Add(n)
+	return
+}
+
+// Close closes the underlying reader if it is a io.Closer.
+func (b *barUpdateReader) Close() error {
+	if c, ok := b.r.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
+}
+
+func backupInstance(ctx *lxminContext, optimized bool, instance, backupNamePrefix string) (string, int64, error) {
+	backup := backupNamePrefix + "_instance.tar.gz"
+	localPath := path.Join(ctx.StagingRoot, backup)
 
 	cmd := exec.Command("lxc", "export", instance, localPath)
-	optimized := c.Bool("optimize")
 	if optimized {
 		cmd = exec.Command("lxc", "export", "--optimized-storage", instance, localPath)
 	}
@@ -117,7 +252,7 @@ func backupMain(c *cli.Context) error {
 
 	p := tea.NewProgram(initSpinnerUI(lxcOpts{
 		instance: instance,
-		message:  `Preparing backup for (%s) instance: %s`,
+		message:  `%s Preparing backup for instance: %s`,
 	}))
 
 	var wg sync.WaitGroup
@@ -139,32 +274,125 @@ func backupMain(c *cli.Context) error {
 
 	wg.Wait()
 
-	f, err := os.Open(localPath)
-	if err != nil {
-		return err
+	if s, err := os.Stat(localPath); err != nil {
+		return "", 0, fmt.Errorf("Unable to stat file %s: %v", localPath, err)
+	} else {
+		return backup, s.Size(), nil
 	}
-	defer os.Remove(localPath)
-	fi, err := f.Stat()
-	if err != nil {
-		return err
+}
+
+func listProfiles(ctx *lxminContext, instance string) ([]string, error) {
+	var outBuf bytes.Buffer
+	cmd := exec.Command("lxc", "config", "show", instance)
+	cmd.Stdout = &outBuf
+
+	p := tea.NewProgram(initSpinnerUI(lxcOpts{
+		instance: instance,
+		message:  `%s Listing profiles for instance: %s`,
+	}))
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := cmd.Run(); err != nil {
+			p.Send(err)
+			log.Fatalln(err)
+		}
+		p.Send(true)
+	}()
+
+	go func() {
+		if err := p.Start(); err != nil {
+			log.Fatalln(err)
+		}
+	}()
+
+	wg.Wait()
+
+	type profileInfo struct {
+		Profiles []string `yaml:"profiles"`
 	}
 
-	usermetadata := map[string]string{}
-	// Save additional information if the backup is optimized or not.
-	usermetadata["optimized"] = strconv.FormatBool(optimized)
-	usermetadata["compressed"] = "true" // This is always true.
-
-	progress := pb.Start64(fi.Size())
-	progress.Set(pb.Bytes, true)
-	progress.SetTemplateString(fmt.Sprintf(tmplUp, backup))
-	barReader := progress.NewProxyReader(f)
-	opts := minio.PutObjectOptions{
-		UserTags:     tagsSet.ToMap(),
-		PartSize:     uint64(partSize),
-		UserMetadata: usermetadata,
-		ContentType:  mime.TypeByExtension(".tar.gz"),
+	var profiles profileInfo
+	if err := yaml.Unmarshal(outBuf.Bytes(), &profiles); err != nil {
+		return nil, fmt.Errorf("Unable to parse profiles list: %v", err)
 	}
-	_, err = globalContext.Clnt.PutObject(context.Background(), globalContext.Bucket, path.Join(instance, backup), barReader, fi.Size(), opts)
-	barReader.Close()
-	return err
+	return profiles.Profiles, nil
+}
+
+type profileInfo struct {
+	FileName string
+	Size     int64
+}
+
+func backupProfiles(ctx *lxminContext, instance, backupNamePrefix string) ([]string, map[string]profileInfo, error) {
+	profiles, err := listProfiles(ctx, instance)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(profiles) > 1000 {
+		log.Fatalf("More than a 1000 profiles per instance not supported.")
+	}
+
+	pInfo := make(map[string]profileInfo, len(profiles))
+	for pno, profile := range profiles {
+		// Profiles are numbered because their order matters - settings
+		// in the later profiles override those from earlier profiles.
+		profileFile := fmt.Sprintf("%s_profile_%03d_%s.yaml", backupNamePrefix, pno, profile)
+		profilePath := path.Join(ctx.StagingRoot, profileFile)
+		pf, err := os.Create(profilePath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("Unable to create backup file %s: %v", profileFile, err)
+		}
+		cmd := exec.Command("lxc", "profile", "show", profile)
+		cmd.Stdout = pf
+
+		p := tea.NewProgram(initSpinnerUI(lxcOpts{
+			instance: instance,
+			message:  `%s Fetching profile '` + profile + `' for instance: %s`,
+		}))
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := cmd.Run(); err != nil {
+				p.Send(err)
+				log.Fatalln(err)
+			}
+			p.Send(true)
+		}()
+
+		go func() {
+			if err := p.Start(); err != nil {
+				log.Fatalln(err)
+			}
+		}()
+
+		wg.Wait()
+
+		// Sync file to disk
+		if err := pf.Sync(); err != nil {
+			return nil, nil, fmt.Errorf("Error syncing profile file %s to disk: %v", profileFile, err)
+		}
+
+		// Save size of the file for showing progress later.
+		if stat, err := pf.Stat(); err != nil {
+			return nil, nil, fmt.Errorf("Unable to stat file %s: %v", profileFile, err)
+		} else {
+			pInfo[profile] = profileInfo{
+				FileName: profileFile,
+				Size:     stat.Size(),
+			}
+		}
+
+		// Close the file
+		if err := pf.Close(); err != nil {
+			return nil, nil, fmt.Errorf("Unable to close file %s: %v", profileFile, err)
+		}
+	}
+
+	return profiles, pInfo, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/minio/cli v1.22.0
 	github.com/minio/minio-go/v7 v7.0.23
 	github.com/minio/pkg v1.1.16
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -127,9 +127,11 @@ golang.org/x/term v0.0.0-20210422114643-f5beecf764ed/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/ini.v1 v1.57.0 h1:9unxIsFcTt4I55uWluz+UmL95q4kdJ0buvQ1ZIqVQww=
 gopkg.in/ini.v1 v1.57.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/urfave/cli.v1 v1.20.0/go.mod h1:vuBzUtMdQeixQj8LVd+/98pzhxNGQoyuPBlsXHOQNO0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/list.go
+++ b/list.go
@@ -96,12 +96,21 @@ func listMain(c *cli.Context) error {
 		if obj.Err != nil {
 			return obj.Err
 		}
+
+		// Do not consider the profiles in the listing.
+		if !strings.HasSuffix(obj.Key, ".tar.gz") {
+			continue
+		}
+
 		inst := path.Clean(instance)
 		if inst == "" || inst == "." {
 			inst = path.Dir(obj.Key)
 		}
+
+		backupName := strings.TrimSuffix(path.Base(obj.Key), "_instance.tar.gz")
+
 		data["Instance"] = append(data["Instance"], inst)
-		data["Name"] = append(data["Name"], path.Base(obj.Key))
+		data["Name"] = append(data["Name"], backupName)
 		data["Created"] = append(data["Created"], obj.LastModified.Format(printDate))
 		data["Size"] = append(data["Size"], humanize.IBytes(uint64(obj.Size)))
 		if _, ok := obj.UserMetadata["X-Amz-Meta-Optimized"]; ok {


### PR DESCRIPTION
- All profiles associated with an instance are backed up to yaml files
preserving their order.

- On restore, a profile that already exists is skipped (not overwritten).

- Listing now shows the name of the backup rather than the name of the tar file.