### PR TITLE
Add notify-endpoint CLI/Env option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,30 +31,32 @@ COMMANDS:
   info        pretty print tags on an instance image on MinIO
   list, ls    list all backups from MinIO
   delete, rm  deletes a specific backup by 'name' for an instance from MinIO
-
+  
 GLOBAL FLAGS:
-  --endpoint value    endpoint for MinIO server [$LXMIN_ENDPOINT]
-  --bucket value      bucket to save/restore backup(s) [$LXMIN_BUCKET]
-  --access-key value  access key credential [$LXMIN_ACCESS_KEY]
-  --secret-key value  secret key credential [$LXMIN_SECRET_KEY]
-  --address value     enable TLS REST API service [$LXMIN_ADDRESS]
-  --cert value        TLS server certificate [$LXMIN_TLS_CERT]
-  --key value         TLS server private key [$LXMIN_TLS_KEY]
-  --capath value      TLS trust certs for incoming clients [$LXMIN_TLS_CAPATH]
-  --staging value     root path for staging the backups before uploading to MinIO [$LXMIN_STAGING_ROOT]
-  --help, -h          show help
-
+  --endpoint value         endpoint for MinIO server [$LXMIN_ENDPOINT]
+  --bucket value           bucket to save/restore backup(s) [$LXMIN_BUCKET]
+  --access-key value       access key credential [$LXMIN_ACCESS_KEY]
+  --secret-key value       secret key credential [$LXMIN_SECRET_KEY]
+  --address value          enable TLS REST API service [$LXMIN_ADDRESS]
+  --cert value             TLS server certificate [$LXMIN_TLS_CERT]
+  --key value              TLS server private key [$LXMIN_TLS_KEY]
+  --capath value           TLS trust certs for incoming clients [$LXMIN_TLS_CAPATH]
+  --notify-endpoint value  HTTP(S) POST endpoint to send notifications for REST API [$LXMIN_NOTIFY_ENDPOINT]
+  --staging value          root path for staging the backups before uploading to MinIO [$LXMIN_STAGING_ROOT]
+  --help, -h               show help
+  
 ENVIRONMENT VARIABLES:
-  LXMIN_ENDPOINT      endpoint for MinIO server
-  LXMIN_BUCKET        bucket to save/restore backup(s)
-  LXMIN_ACCESS_KEY    access key credential
-  LXMIN_SECRET_KEY    secret key credential
-  LXMIN_ADDRESS       enable TLS REST API service
-  LXMIN_TLS_CERT      TLS server certificate
-  LXMIN_TLS_KEY       TLS server private key
-  LXMIN_TLS_CAPATH    TLS trust certs for incoming clients
-  LXMIN_STAGING_ROOT  root path for staging the backups before uploading to MinIO
-
+  LXMIN_ENDPOINT         endpoint for MinIO server
+  LXMIN_BUCKET           bucket to save/restore backup(s)
+  LXMIN_ACCESS_KEY       access key credential
+  LXMIN_SECRET_KEY       secret key credential
+  LXMIN_ADDRESS          enable TLS REST API service
+  LXMIN_TLS_CERT         TLS server certificate
+  LXMIN_TLS_KEY          TLS server private key
+  LXMIN_TLS_CAPATH       TLS trust certs for incoming clients
+  LXMIN_NOTIFY_ENDPOINT  HTTP(S) POST endpoint to send notifications for REST API
+  LXMIN_STAGING_ROOT     root path for staging the backups before uploading to MinIO
+  
 ```
 
 ## REST API
@@ -90,12 +92,12 @@ Response type for this API will be always `application/json`
 
 ### POST /1.0/instances/{name}/backups
 
-| Query Params   | Desc                                                                         |
-|:---------------|:-----------------------------------------------------------------------------|
-| optimize       | enables optimized backup for faster restore operations                       |
-| tags           | allow custom tags on the current backup                                      |
-| notifyEndpoint | notification endpoint for success/failed backup operation                    |
-| partSize       | custom part size used for uploading to MinIO storage, defaults to '67108864' |
+| Query Params   | Desc                                                                                |
+|:---------------|:------------------------------------------------------------------------------------|
+| optimize       | enables optimized backup for faster restore operations                              |
+| tags           | allow custom tags on the current backup                                             |
+| notifyEndpoint | notification endpoint for success/failed backup operation (overrides env/CLI value) |
+| partSize       | custom part size used for uploading to MinIO storage, defaults to '67108864'        |
 
 Response example:
 
@@ -168,9 +170,9 @@ Response example when backup is persisted:
 
 ### POST /1.0/instances/{name}/backups/{backup}
 
-| Query Params   | Desc                                                       |
-|:---------------|:-----------------------------------------------------------|
-| notifyEndpoint | notification endpoint for success/failed restore operation |
+| Query Params   | Desc                                                                                 |
+|:---------------|:-------------------------------------------------------------------------------------|
+| notifyEndpoint | notification endpoint for success/failed restore operation (overrides env/CLI value) |
 
 Response example:
 

--- a/globals.go
+++ b/globals.go
@@ -78,6 +78,7 @@ func setGlobalsFromContext(c *cli.Context) error {
 		globalContext.RootCAs = rootCAs
 	}
 
+	globalContext.NotifyEndpoint = c.String("notify-endpoint")
 	globalContext.NotifyClnt = &http.Client{
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,

--- a/lxc.go
+++ b/lxc.go
@@ -209,7 +209,7 @@ func listProfiles(instance string) ([]string, error) {
 	cmd.Stdout = &outBuf
 
 	if err := cmd.Run(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Unable get instance config: %v", err)
 	}
 
 	type profileInfo struct {
@@ -232,7 +232,7 @@ func exportProfile(profile, dstPath string) (int64, error) {
 	cmd := exec.Command("lxc", "profile", "show", profile)
 	cmd.Stdout = pf
 	if err := cmd.Run(); err != nil {
-		return -1, err
+		return -1, fmt.Errorf("Unable to export profile: %v", err)
 	}
 
 	// Sync file to disk
@@ -262,7 +262,7 @@ func exportInstance(instance, dstFile string, optimized bool) (int64, error) {
 	cmd.Stdout = ioutil.Discard
 
 	if err := cmd.Run(); err != nil {
-		return -1, err
+		return -1, fmt.Errorf("Unable to export instance: %v", err)
 	}
 
 	s, err := os.Stat(dstFile)
@@ -280,7 +280,7 @@ func fetchExistingProfiles() (s set.StringSet, err error) {
 	cmd.Stdout = &outBuf
 
 	if err := cmd.Run(); err != nil {
-		return s, err
+		return s, fmt.Errorf("Unable to list profiles: %v", err)
 	}
 
 	type profileInfo struct {

--- a/lxmin.go
+++ b/lxmin.go
@@ -41,12 +41,13 @@ type backupMeta struct {
 }
 
 type lxminContext struct {
-	Clnt        *minio.Client
-	Bucket      string
-	StagingRoot string
-	TLSCerts    *certs.Manager
-	RootCAs     *x509.CertPool
-	NotifyClnt  *http.Client
+	Clnt           *minio.Client
+	Bucket         string
+	StagingRoot    string
+	TLSCerts       *certs.Manager
+	RootCAs        *x509.CertPool
+	NotifyClnt     *http.Client
+	NotifyEndpoint string
 }
 
 // GetTags - fetch tags on the backup.

--- a/main.go
+++ b/main.go
@@ -82,6 +82,11 @@ var globalFlags = []cli.Flag{
 		Usage:  "TLS trust certs for incoming clients",
 	},
 	cli.StringFlag{
+		Name:   "notify-endpoint",
+		EnvVar: "LXMIN_NOTIFY_ENDPOINT",
+		Usage:  "HTTP(S) POST endpoint to send notifications for REST API",
+	},
+	cli.StringFlag{
 		Name:   "staging",
 		EnvVar: "LXMIN_STAGING_ROOT",
 		Usage:  "root path for staging the backups before uploading to MinIO",


### PR DESCRIPTION
- Fixes an existing issue where if the notification endpoint is not specified in
  the REST API call, the operation appears to fail silently.

- If not specified in the REST API call, this value is used.

- If no notify-endpoint is given, an error is without performing the
  backup/restore operation.

- Improve some error messages.